### PR TITLE
Fix value of 'speed' when set default is 'auto'

### DIFF
--- a/jquery.smooth-scroll.js
+++ b/jquery.smooth-scroll.js
@@ -169,11 +169,15 @@ $.smoothScroll = function(options, px) {
   // automatically calculate the speed of the scroll based on distance / coefficient
   if (speed === 'auto') {
 
-    // if aniProps[scrollDir] == 0 then we'll use scrollTop() value instead
-    speed = aniProps[scrollDir] || $scroller.scrollTop();
+    // $scroller.scrollTop() is brefore scroll, aniProps[scrollDir] is after scroll
+    //'delta' is value changing. When 'delta' bigger, then 'speed' will be larger same and vice versa.
+    var delta = aniProps[scrollDir] - $scroller.scrollTop();
+    if(delta < 0) {
+      delta *= -1;
+    }
 
     // divide the speed by the coefficient
-    speed = speed / opts.autoCoefficent;
+    speed = delta / opts.autoCoefficent;
   }
 
   aniOpts = {


### PR DESCRIPTION
I fixed problem about 'speed' when set default it is 'auto'.
- Old logic: 
  speed very slow when move scroll has delta is small. But it very quickly when go to bottom to top because it has value is 0.
- New logic: 
  speed calculate by delta of scroll move. So it always run normally, not quickly/slow when move scroll.
  See test: http://svbuichu.com/javascript/ipad-test/

Other problem I found:
Now, when I used it on Ipad2, sometime, it do not work when click next action to scroll.
