### PR TITLE
Added proper commonjs support

### DIFF
--- a/jquery.smooth-scroll.js
+++ b/jquery.smooth-scroll.js
@@ -9,6 +9,9 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['jquery'], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // CommonJS
+    factory(require('jquery'));
   } else {
     // Browser globals
     factory(jQuery);


### PR DESCRIPTION
Right now you're relying on `window.jQuery`. I don't have that global var, so this library wasn't working for me.