### PR TITLE
add optional support for event delegation

### DIFF
--- a/src/jquery.smooth-scroll.js
+++ b/src/jquery.smooth-scroll.js
@@ -9,6 +9,10 @@
         // one of 'top' or 'left'
         direction: 'top',
 
+        // if set, bind click events through delegation
+        //  supported since jQuery 1.4.2
+        delegateSelector: null,
+
         // jQuery set of elements you wish to scroll (for $.smoothScroll).
         //  if null (default), $('html, body').firstScrollable() is used.
         scrollElement: null,
@@ -113,9 +117,7 @@
       var opts = $.extend({}, $.fn.smoothScroll.defaults, options),
           locationPath = $.smoothScroll.filterPath(location.pathname);
 
-      this
-      .unbind('click.smoothscroll')
-      .bind('click.smoothscroll', function(event) {
+      var clickHandler = function(event) {
         var link = this,
             $link = $(this),
             thisOpts = $.extend({}, opts, $link.data('ssOpts') || {}),
@@ -156,7 +158,17 @@
 
           $.smoothScroll( clickOpts );
         }
-      });
+      };
+
+      if(options.delegateSelector !== null){
+        this
+          .undelegate(options.delegateSelector, 'click.smoothscroll')
+          .delegate(options.delegateSelector, 'click.smoothscroll', clickHandler);
+      }else{
+        this
+          .unbind('click.smoothscroll')
+          .bind('click.smoothscroll', clickHandler);
+      }
 
       return this;
     }

--- a/src/jquery.smooth-scroll.js
+++ b/src/jquery.smooth-scroll.js
@@ -160,11 +160,11 @@
         }
       };
 
-      if(options.delegateSelector !== null){
+      if (options.delegateSelector !== null) {
         this
           .undelegate(options.delegateSelector, 'click.smoothscroll')
           .delegate(options.delegateSelector, 'click.smoothscroll', clickHandler);
-      }else{
+      } else {
         this
           .unbind('click.smoothscroll')
           .bind('click.smoothscroll', clickHandler);


### PR DESCRIPTION
To support click handling for elements that are not already on the page at initialization. 

Will only work with jQuery 1.4.2 and up, but is backwards compatible as long as `delegateSelector` is not set.